### PR TITLE
RAC-Host#31: Add `KGraph`

### DIFF
--- a/rac-host/src/articulation.rs
+++ b/rac-host/src/articulation.rs
@@ -11,11 +11,11 @@ enum ArticulationStatus {
     Lost,
 }
 
-struct Articulation<T> {
+pub struct Articulation<T> {
     id: usize,
     pose: na::Isometry3<T>,
     status: ArticulationStatus,
-    core: Option<CoreArticulation<T>>
+    core: Option<CoreArticulation<T>>,
 }
 
 impl<T: RealField> Articulation<T> {
@@ -28,15 +28,15 @@ impl<T: RealField> Articulation<T> {
         }
     }
 
-    pub fn get_pose(&self) -> &na::Isometry3<T>{
+    pub fn get_pose(&self) -> &na::Isometry3<T> {
         &self.pose
     }
 
-    pub fn get_status(&self) -> ArticulationStatus{
+    pub fn get_status(&self) -> ArticulationStatus {
         self.status
     }
 
-    pub fn get_core(&self) -> Option<&CoreArticulation<T>>{
+    pub fn get_core(&self) -> Option<&CoreArticulation<T>> {
         self.core.as_ref()
     }
 }
@@ -72,7 +72,10 @@ mod test {
     fn host_articulation_new() {
         let art = Articulation::<f64>::new(1);
 
-        assert_eq!(art.get_status(), articulation::ArticulationStatus::Unidentified);
+        assert_eq!(
+            art.get_status(),
+            articulation::ArticulationStatus::Unidentified
+        );
         assert_eq!(art.get_core(), None);
         assert_eq!(art.get_pose(), &na::Isometry3::identity());
     }

--- a/rac-host/src/kgraph.rs
+++ b/rac-host/src/kgraph.rs
@@ -5,3 +5,15 @@ struct KGraph<T> {
     /// KController to use as a reference
     articulations: Vec<Articulation<T>>,
 }
+
+impl<T> KGraph<T> {
+    pub fn new() -> Self {
+        KGraph {
+            articulations: Vec::new(),
+        }
+    }
+
+    pub fn add_node(&mut self, node: Articulation<T>) {
+        self.articulations.push(node);
+    }
+}

--- a/rac-host/src/kgraph.rs
+++ b/rac-host/src/kgraph.rs
@@ -1,0 +1,7 @@
+use crate::articulation::Articulation;
+
+struct KGraph<T> {
+    /// The theorerical state of the articulations is stored for the
+    /// KController to use as a reference
+    articulations: Vec<Articulation<T>>,
+}

--- a/rac-host/src/lib.rs
+++ b/rac-host/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod articulation;
 pub mod kcontroller;
+pub mod kgraph;
 
 // TODO - default traits to send messages
 trait SendMsg {


### PR DESCRIPTION
The KGraph type is the one that makes the kinematic calculations, however this is for a later development stage. The current requirement is to just define the articulations that the `KController` needs to register the `KNodes` that must exist in the network.