### PR TITLE
RAC Core: Add KNode `command_handler`

### DIFF
--- a/rac-core/src/knode.rs
+++ b/rac-core/src/knode.rs
@@ -8,8 +8,8 @@ pub struct KNode {
     pub id: u8,
     pub status: Status,
     art_status: Option<CoreArticulationStatus>,
-    rx_queue: BinaryHeap<KNodeMsg, Max, 8>,
-    tx_queue: BinaryHeap<KNodeMsg, Max, 8>,
+    pub rx_queue: BinaryHeap<KNodeMsg, Max, 8>,
+    pub tx_queue: BinaryHeap<KNodeMsg, Max, 8>,
     pub controller_id: u8,
     pub heartbeat_timeout: u32,
 }
@@ -32,7 +32,10 @@ impl KNode {
         self.controller_id = controller_id;
         self.heartbeat_timeout = timeout;
 
-        self.tx_enqueue(
+        // At this point the KNode is Initializing so we
+        // can safely assume that the queues are not full
+        // TODO - Send a response instead of a heartbeat
+        let _ = self.tx_queue.push(
             KNodeMsg::heartbeat()
                 .set_sender(self.id)
                 .set_receiver(self.controller_id),
@@ -46,39 +49,9 @@ impl KNode {
         }
     }
 
-    // For RX Queue
-    pub fn rx_enqueue(&mut self, msg: KNodeMsg) -> KNodeErr {
-        match self.rx_queue.push(msg) {
-            Ok(_) => KNodeErr::Ok,
-            Err(_) => KNodeErr::BufferFull,
-        }
-    }
-
-    pub fn rx_dequeue(&mut self) -> Result<KNodeMsg, KNodeErr> {
-        match self.rx_queue.pop() {
-            Some(msg) => Ok(msg),
-            None => Err(KNodeErr::BufferFull),
-        }
-    }
-
-    // For TX Queue
-    pub fn tx_enqueue(&mut self, msg: KNodeMsg) -> KNodeErr {
-        match self.tx_queue.push(msg) {
-            Ok(_) => KNodeErr::Ok,
-            Err(_) => KNodeErr::BufferFull,
-        }
-    }
-
-    pub fn tx_dequeue(&mut self) -> Result<KNodeMsg, KNodeErr> {
-        match self.tx_queue.pop() {
-            Some(msg) => Ok(msg),
-            None => Err(KNodeErr::BufferFull),
-        }
-    }
-
     /// Get a message sent by the KController and process it
     pub fn process(&mut self) {
-        let msg = self.rx_dequeue().unwrap();
+        let msg = self.rx_queue.pop().unwrap();
         // Check what message the KController sent and update state accoringly
         match msg.get_priotiry() {
             KNodeMsgKind::Command => self.commands_handler(msg),

--- a/rac-core/src/knode.rs
+++ b/rac-core/src/knode.rs
@@ -1,30 +1,42 @@
 use crate::articulation::{CoreArticulationStatus, CoreArticulationVariant};
 use crate::Status;
 use heapless::binary_heap::{BinaryHeap, Max};
-use rac_protocol::knode_protocol::{KNodeErr, KNodeMsg};
+use rac_protocol::knode_protocol::{KNodeCommand, KNodeErr, KNodeMsg, KNodeMsgKind, KNodePayload};
 
 /// Description of an CoreArticulation in order to be represented in a Graph
 pub struct KNode {
-    id: usize,
-    status: Status,
+    pub id: u8,
+    pub status: Status,
     art_status: Option<CoreArticulationStatus>,
     rx_queue: BinaryHeap<KNodeMsg, Max, 8>,
     tx_queue: BinaryHeap<KNodeMsg, Max, 8>,
+    pub controller_id: u8,
+    pub heartbeat_timeout: u32,
 }
 
 impl KNode {
-    pub fn new(new_id: usize) -> Self {
+    pub fn new(new_id: u8) -> Self {
         Self {
             id: new_id,
             status: Status::Uninitialized,
             art_status: Option::None,
             rx_queue: BinaryHeap::new(),
             tx_queue: BinaryHeap::new(),
+            controller_id: 0,
+            heartbeat_timeout: 0,
         }
     }
 
-    pub fn init(&mut self) {
+    pub fn init(&mut self, controller_id: u8, timeout: u32) {
         self.status = Status::Active;
+        self.controller_id = controller_id;
+        self.heartbeat_timeout = timeout;
+
+        self.tx_enqueue(
+            KNodeMsg::heartbeat()
+                .set_sender(self.id)
+                .set_receiver(self.controller_id),
+        );
     }
 
     pub fn register_art(&mut self, art: &CoreArticulationVariant) {
@@ -61,6 +73,31 @@ impl KNode {
         match self.tx_queue.pop() {
             Some(msg) => Ok(msg),
             None => Err(KNodeErr::BufferFull),
+        }
+    }
+
+    /// Get a message sent by the KController and process it
+    pub fn process(&mut self) {
+        let msg = self.rx_dequeue().unwrap();
+        // Check what message the KController sent and update state accoringly
+        match msg.get_priotiry() {
+            KNodeMsgKind::Command => self.commands_handler(msg),
+            _ => return,
+        }
+        // For the init message change status to Initializing
+        // Branch to the actual Initializing
+        // Push to the TX queue a Initialized messaged if successful
+        // Push to the TX queue an Err
+    }
+
+    /// KNode command handler
+    fn commands_handler(&mut self, msg: KNodeMsg) {
+        if let KNodePayload::Command(cmd) = msg.payload {
+            // Check the command type
+            match cmd {
+                KNodeCommand::Initialize { kcont_id, timeout } => self.init(kcont_id, timeout),
+                _ => (),
+            };
         }
     }
 }

--- a/rac-host/src/kcontroller.rs
+++ b/rac-host/src/kcontroller.rs
@@ -1,12 +1,18 @@
+use core::time;
 use rac_core::knode::KNode;
 use rac_core::Status;
 use rac_protocol::knode_protocol::{KNodeCommand, KNodeErr, KNodeMsg, KNodeResponse};
-use std::collections::{BinaryHeap, HashMap};
+use std::{
+    collections::{BinaryHeap, HashMap},
+    usize,
+};
+
+/// Default KNode timeout in ms
+static KNODE_DEF_TIMEOUT: u32 = 500;
 
 struct KNodeInfo {
-    id: u8,
     status: Status,
-    timeout: usize,
+    timeout: u32,
     last_cmd: KNodeCommand,
     last_rsp: KNodeResponse,
 }
@@ -37,6 +43,7 @@ struct KController {
     status: Status,
     msgs_in: BinaryHeap<KNodeMsg>,
     msgs_out: BinaryHeap<KNodeMsg>,
+    htimeout: usize,
 }
 
 impl KController {
@@ -47,19 +54,40 @@ impl KController {
             status: Status::Uninitialized,
             msgs_in: BinaryHeap::new(),
             msgs_out: BinaryHeap::new(),
+            htimeout: usize::MAX,
         }
     }
 
     fn init(&mut self) {
-        let node_ids: Vec<u8> = self.nodes.keys().cloned().collect();
-        let mut cmd_init = KNodeMsg::command(KNodeCommand::Initialize);
-        for id in node_ids {
-            cmd_init.set_sender(self.id);
-            cmd_init.set_receiver(id);
+        // Send an init command to all the KNodes in the network
+        for (id, node_info) in &self.nodes {
+            let cmd_init = KNodeMsg::command(KNodeCommand::Initialize {
+                kcont_id: self.id,
+                timeout: node_info.timeout,
+            })
+            .set_sender(self.id)
+            .set_receiver(id.clone());
             self.msgs_out.push(cmd_init);
             // Stablish a timeout to track the node initialization process - TODO
         }
+
         self.status = Status::Initializing;
+    }
+
+    pub fn add_node(&mut self, node: &KNode, timeout: Option<u32>) {
+        let ntimeout = match timeout {
+            None => KNODE_DEF_TIMEOUT,
+            Some(num) => num,
+        };
+
+        let node_info = KNodeInfo {
+            status: Status::Uninitialized,
+            timeout: ntimeout,
+            last_cmd: KNodeCommand::InvalidCommand,
+            last_rsp: KNodeResponse::InvalidResponse,
+        };
+
+        self.nodes.insert(node.id, node_info);
     }
 
     // TODO - read articulation
@@ -79,6 +107,7 @@ mod test {
         KNodeCommand, KNodeErr, KNodeMsg, KNodeMsgKind, KNodeResponse,
     };
 
+    /// Virtual channel between nodes for KNode priority checks
     fn channel_send_knodemsg(sender: &mut KNode, receiver: &mut KNode) {
         while let Ok(sent_msg) = sender.tx_dequeue() {
             receiver.rx_enqueue(sent_msg);
@@ -109,15 +138,18 @@ mod test {
         }
     }
 
-    #[test]
     /// Check the KNodeMsg priotity when emptying a KNode queue
+    #[test]
     fn check_msg_priority() {
         let mut knode = KNode::new(1);
         let debug_data = [42u8; 32];
 
         let msgs: [KNodeMsg; 5] = [
             KNodeMsg::heartbeat(),
-            KNodeMsg::command(KNodeCommand::Initialize),
+            KNodeMsg::command(KNodeCommand::Initialize {
+                kcont_id: 255,
+                timeout: KNODE_DEF_TIMEOUT,
+            }),
             KNodeMsg::debug(0, 8, debug_data),
             KNodeMsg::error(KNodeErr::InitializationErr),
             KNodeMsg::response(KNodeResponse::Initilized),
@@ -160,7 +192,10 @@ mod test {
         let debug_data = [42u8; 32];
         let msgs: [KNodeMsg; 5] = [
             KNodeMsg::heartbeat(),
-            KNodeMsg::command(KNodeCommand::Initialize),
+            KNodeMsg::command(KNodeCommand::Initialize {
+                kcont_id: 255,
+                timeout: KNODE_DEF_TIMEOUT,
+            }),
             KNodeMsg::debug(0, 8, debug_data),
             KNodeMsg::error(KNodeErr::InitializationErr),
             KNodeMsg::response(KNodeResponse::Initilized),
@@ -197,12 +232,28 @@ mod test {
     }
 
     /// Check the KController sends a heartbeat to a KNode
+    /// This test is a bit lacking since the data is has not been serialized. We need to serialize the data correctly and then send it correctly.
+    ///
+    /// This test might have to be modified when we add an abstraction layer to send messages through an interface.
     #[test]
-    fn kcontroller_recv_hearthbeat() {
+    fn kcontroller_send_heartbeat() {
         let mut kcont = KController::new();
+
+        let mut knode = KNode::new(1);
+
+        kcont.add_node(&knode, Some(KNODE_DEF_TIMEOUT));
 
         kcont.init();
 
         assert_eq!(kcont.status, Status::Initializing);
+
+        // Pop the KController messages and insert these into the KNode
+        knode.rx_enqueue(kcont.msgs_out.pop().unwrap());
+
+        // Check that the messages are processed
+        knode.process();
+        assert_eq!(knode.status, Status::Active);
+        assert_eq!(knode.controller_id, kcont.id);
+        assert_eq!(knode.heartbeat_timeout, KNODE_DEF_TIMEOUT);
     }
 }

--- a/rac-host/src/kcontroller.rs
+++ b/rac-host/src/kcontroller.rs
@@ -109,8 +109,8 @@ mod test {
 
     /// Virtual channel between nodes for KNode priority checks
     fn channel_send_knodemsg(sender: &mut KNode, receiver: &mut KNode) {
-        while let Ok(sent_msg) = sender.tx_dequeue() {
-            receiver.rx_enqueue(sent_msg);
+        while let Some(sent_msg) = sender.tx_queue.pop() {
+            let _ = receiver.rx_queue.push(sent_msg);
         }
     }
 
@@ -122,25 +122,25 @@ mod test {
         // Fill the sender queue
         for _ in 0..8 {
             let msg = KNodeMsg::heartbeat();
-            assert_eq!(sender.tx_enqueue(msg), KNodeErr::Ok);
+            assert_eq!(sender.tx_queue.push(msg), Ok(()));
         }
 
         // Overflow the buffer sending one extra message
         let msg = KNodeMsg::heartbeat();
-        assert_eq!(sender.tx_enqueue(msg), KNodeErr::BufferFull);
+        assert_eq!(sender.tx_queue.push(msg), Err(msg));
 
         // Send the msgs to the receiver
         channel_send_knodemsg(&mut sender, &mut receiver);
 
         // Empty the receiver queue
         for _ in 0..8 {
-            assert_eq!(receiver.rx_dequeue(), Ok(KNodeMsg::heartbeat()));
+            assert_eq!(receiver.rx_queue.pop(), Some(KNodeMsg::heartbeat()));
         }
     }
 
     /// Check the KNodeMsg priotity when emptying a KNode queue
     #[test]
-    fn check_msg_priority() {
+    fn knode_check_msg_priority() {
         let mut knode = KNode::new(1);
         let debug_data = [42u8; 32];
 
@@ -156,33 +156,49 @@ mod test {
         ];
 
         for i in 0..5 {
-            let _ = knode.tx_enqueue(msgs[i]);
+            let _ = knode.tx_queue.push(msgs[i]);
         }
 
         assert_eq!(
-            knode.tx_dequeue().expect("Expected Ok").get_priotiry(),
+            knode.tx_queue.pop().expect("Expected Ok").get_priotiry(),
             KNodeMsgKind::Err
         );
 
         assert_eq!(
-            knode.tx_dequeue().expect("Expected Ok").get_priotiry(),
+            knode.tx_queue.pop().expect("Expected Ok").get_priotiry(),
             KNodeMsgKind::Heartbeat
         );
 
         assert_eq!(
-            knode.tx_dequeue().expect("Expected Ok").get_priotiry(),
+            knode.tx_queue.pop().expect("Expected Ok").get_priotiry(),
             KNodeMsgKind::Command
         );
 
         assert_eq!(
-            knode.tx_dequeue().expect("Expected Ok").get_priotiry(),
+            knode.tx_queue.pop().expect("Expected Ok").get_priotiry(),
             KNodeMsgKind::Response
         );
 
         assert_eq!(
-            knode.tx_dequeue().expect("Expected Ok").get_priotiry(),
+            knode.tx_queue.pop().expect("Expected Ok").get_priotiry(),
             KNodeMsgKind::Debug
         );
+    }
+
+    #[test]
+    fn knode_check_queues() {
+        let mut knode = KNode::new(1);
+
+        // Check that the KNode gives the proper error when the rx_queue
+        // is empty and we try to get a message
+        let empty_msg = knode.rx_queue.pop();
+        assert_eq!(empty_msg, None);
+
+        let msg = KNodeMsg::heartbeat();
+        for _ in 0..8 {
+            let err = knode.rx_queue.push(msg);
+            assert_eq!(err.unwrap(), ())
+        }
     }
 
     #[test]
@@ -248,7 +264,7 @@ mod test {
         assert_eq!(kcont.status, Status::Initializing);
 
         // Pop the KController messages and insert these into the KNode
-        knode.rx_enqueue(kcont.msgs_out.pop().unwrap());
+        let _ = knode.rx_queue.push(kcont.msgs_out.pop().unwrap());
 
         // Check that the messages are processed
         knode.process();

--- a/rac-protocol/src/knode_protocol.rs
+++ b/rac-protocol/src/knode_protocol.rs
@@ -107,6 +107,7 @@ pub enum KNodePayload {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum KNodeErr {
     InitializationErr,
+    BufferEmpty,
     BufferFull,
     Ok,
 }

--- a/rac-protocol/src/knode_protocol.rs
+++ b/rac-protocol/src/knode_protocol.rs
@@ -4,8 +4,8 @@ use core::cmp::Ord;
 pub struct KNodeMsg {
     sender: u8,
     receiver: u8,
-    kind: KNodeMsgKind,
-    payload: KNodePayload,
+    pub kind: KNodeMsgKind,
+    pub payload: KNodePayload,
 }
 
 impl KNodeMsg {
@@ -13,12 +13,14 @@ impl KNodeMsg {
         self.kind
     }
 
-    pub fn set_sender(&mut self, s: u8) {
-        self.sender = s.clone();
+    pub fn set_sender(mut self, s: u8) -> Self {
+        self.sender = s;
+        self
     }
 
-    pub fn set_receiver(&mut self, r: u8) {
-        self.receiver = r.clone();
+    pub fn set_receiver(mut self, r: u8) -> Self {
+        self.receiver = r;
+        self
     }
 
     pub fn heartbeat() -> Self {
@@ -111,12 +113,14 @@ pub enum KNodeErr {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum KNodeCommand {
-    Initialize,
+    InvalidCommand,
+    Initialize { kcont_id: u8, timeout: u32 },
     GetData,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum KNodeResponse {
+    InvalidResponse,
     Initilized,
     DataSent,
 }


### PR DESCRIPTION
The KNone needs a way to handle the messages sent by the KController, this will be implemented into a handler that will respond generating the correct response message for the KController. This PR adds the starting handler that will only respond to the KController initialization and a KNode command handler to handle the commands sent by the KController.

It succesfully updates the uninitialized KNode into its Active status state. I have also discovered that I handle the queue errors on the KNode like aged milk, with a lot of terrible smells. An issue has been created for this.